### PR TITLE
Debug communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ $config->storeName = "example store name";
 $config->apiKey = "ExamPleApiKey";
 $config->encryptPublicKey = "publicKeyGoesHere";
 $config->testMode = true;
+$config->debugCommunication = true; // Get info about the communication (curl) with the payment gateway
 
 $paymentGateway = new \Nevogate\PaymentGateway($config);
 ```

--- a/src/Nevogate/PaymentGateway/Config.php
+++ b/src/Nevogate/PaymentGateway/Config.php
@@ -131,12 +131,12 @@ XIm63iVw6gjP2qDnNwIDAQAB
 	 */
 	protected $gatewayProxy = '';
 
-    /**
-     * Add debug information to the Response object
-     *
-     * @var bool
-     */
-    public $debugCommunication = false;
+	/**
+	 * Add debug information to the Response object
+	 *
+	 * @var bool
+	 */
+	public $debugCommunication = false;
 
 	/**
 	 * @return bool

--- a/src/Nevogate/PaymentGateway/Config.php
+++ b/src/Nevogate/PaymentGateway/Config.php
@@ -131,6 +131,13 @@ XIm63iVw6gjP2qDnNwIDAQAB
 	 */
 	protected $gatewayProxy = '';
 
+    /**
+     * Add debug information to the Response object
+     *
+     * @var bool
+     */
+    public $debugCommunication = false;
+
 	/**
 	 * @return bool
 	 */

--- a/src/Nevogate/PaymentGateway/Config.php
+++ b/src/Nevogate/PaymentGateway/Config.php
@@ -136,7 +136,7 @@ XIm63iVw6gjP2qDnNwIDAQAB
 	 *
 	 * @var bool
 	 */
-	public $debugCommunication = false;
+	protected $debugCommunication = false;
 
 	/**
 	 * @return bool
@@ -197,6 +197,16 @@ XIm63iVw6gjP2qDnNwIDAQAB
 
 		return static::API_URL_PRODUCTION;
 	}
+
+    public function isDebugCommunication(): bool
+    {
+        return $this->debugCommunication;
+    }
+
+    public function setDebugCommunication(bool $debugCommunication): void
+    {
+        $this->debugCommunication = $debugCommunication;
+    }
 
 	/**
 	 * @param string $name

--- a/src/Nevogate/PaymentGateway/Config.php
+++ b/src/Nevogate/PaymentGateway/Config.php
@@ -203,11 +203,6 @@ XIm63iVw6gjP2qDnNwIDAQAB
         return $this->debugCommunication;
     }
 
-    public function setDebugCommunication(bool $debugCommunication): void
-    {
-        $this->debugCommunication = $debugCommunication;
-    }
-
 	/**
 	 * @param string $name
 	 * @param mixed $value

--- a/src/Nevogate/PaymentGateway/Transport/Response/Response.php
+++ b/src/Nevogate/PaymentGateway/Transport/Response/Response.php
@@ -77,10 +77,10 @@ class Response implements ResponseInterface
 		$this->data = $data;
 	}
 
-    public function setSdkDebugInfo(array $sdkDebugInfo)
-    {
-        $this->data['sdkDebugInfo'] = $sdkDebugInfo;
-    }
+	public function setSdkDebugInfo(array $sdkDebugInfo)
+	{
+		$this->data['sdkDebugInfo'] = $sdkDebugInfo;
+	}
 
 	/**
 	 * @param string $name

--- a/src/Nevogate/PaymentGateway/Transport/Response/Response.php
+++ b/src/Nevogate/PaymentGateway/Transport/Response/Response.php
@@ -77,6 +77,11 @@ class Response implements ResponseInterface
 		$this->data = $data;
 	}
 
+    public function setSdkDebugInfo(array $sdkDebugInfo)
+    {
+        $this->data['sdkDebugInfo'] = $sdkDebugInfo;
+    }
+
 	/**
 	 * @param string $name
 	 * @return string|null

--- a/src/Nevogate/PaymentGateway/Transport/SystemTransport.php
+++ b/src/Nevogate/PaymentGateway/Transport/SystemTransport.php
@@ -135,19 +135,19 @@ class SystemTransport
 
         $sdkDebugInfo = [];
 
-        if ($this->config->debugCommunication) {
-            $sdkDebugInfo = array(
-                'curl_getinfo' => curl_getinfo($curl),
-                'post_data' => $postData
-            );
-        }
+		if ($this->config->debugCommunication) {
+			$sdkDebugInfo = array(
+				'curl_getinfo' => curl_getinfo($curl),
+				'post_data' => $postData
+			);
+		}
 
 		curl_close($curl);
 
 		$response = Response::createFromJson($httpResponse);
-        if (count($sdkDebugInfo) > 0) {
-            $response->setSdkDebugInfo($sdkDebugInfo);
-        }
+		if (count($sdkDebugInfo) > 0) {
+			$response->setSdkDebugInfo($sdkDebugInfo);
+		}
 		$this->convertOutResponse($response);
 		return $response;
 	}

--- a/src/Nevogate/PaymentGateway/Transport/SystemTransport.php
+++ b/src/Nevogate/PaymentGateway/Transport/SystemTransport.php
@@ -117,9 +117,9 @@ class SystemTransport
 		curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
 		curl_setopt($curl, CURLOPT_USERAGENT, $this->getUserAgent($request->getMethod()));
 
-        if ($this->config->debugCommunication) {
-            curl_setopt($curl, CURLINFO_HEADER_OUT, true);
-        }
+		if ($this->config->debugCommunication) {
+			curl_setopt($curl, CURLINFO_HEADER_OUT, true);
+		}
 
 		if ($this->config->getGatewayProxy() != '') {
 			curl_setopt($curl, CURLOPT_PROXY, $this->config->getGatewayProxy());
@@ -133,7 +133,7 @@ class SystemTransport
 			throw $exception;
 		}
 
-        $sdkDebugInfo = [];
+		$sdkDebugInfo = [];
 
 		if ($this->config->debugCommunication) {
 			$sdkDebugInfo = array(

--- a/src/Nevogate/PaymentGateway/Transport/SystemTransport.php
+++ b/src/Nevogate/PaymentGateway/Transport/SystemTransport.php
@@ -117,6 +117,10 @@ class SystemTransport
 		curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
 		curl_setopt($curl, CURLOPT_USERAGENT, $this->getUserAgent($request->getMethod()));
 
+        if ($this->config->debugCommunication) {
+            curl_setopt($curl, CURLINFO_HEADER_OUT, true);
+        }
+
 		if ($this->config->getGatewayProxy() != '') {
 			curl_setopt($curl, CURLOPT_PROXY, $this->config->getGatewayProxy());
 		}
@@ -129,9 +133,21 @@ class SystemTransport
 			throw $exception;
 		}
 
+        $sdkDebugInfo = [];
+
+        if ($this->config->debugCommunication) {
+            $sdkDebugInfo = array(
+                'curl_getinfo' => curl_getinfo($curl),
+                'post_data' => $postData
+            );
+        }
+
 		curl_close($curl);
 
 		$response = Response::createFromJson($httpResponse);
+        if (count($sdkDebugInfo) > 0) {
+            $response->setSdkDebugInfo($sdkDebugInfo);
+        }
 		$this->convertOutResponse($response);
 		return $response;
 	}

--- a/src/Nevogate/PaymentGateway/Transport/SystemTransport.php
+++ b/src/Nevogate/PaymentGateway/Transport/SystemTransport.php
@@ -117,7 +117,7 @@ class SystemTransport
 		curl_setopt($curl, CURLOPT_POSTFIELDS, $postData);
 		curl_setopt($curl, CURLOPT_USERAGENT, $this->getUserAgent($request->getMethod()));
 
-		if ($this->config->debugCommunication) {
+		if ($this->config->isDebugCommunication()) {
 			curl_setopt($curl, CURLINFO_HEADER_OUT, true);
 		}
 
@@ -135,7 +135,7 @@ class SystemTransport
 
 		$sdkDebugInfo = [];
 
-		if ($this->config->debugCommunication) {
+		if ($this->config->isDebugCommunication()) {
 			$sdkDebugInfo = array(
 				'curl_getinfo' => curl_getinfo($curl),
 				'post_data' => $postData
@@ -145,9 +145,11 @@ class SystemTransport
 		curl_close($curl);
 
 		$response = Response::createFromJson($httpResponse);
+
 		if (count($sdkDebugInfo) > 0) {
 			$response->setSdkDebugInfo($sdkDebugInfo);
 		}
+
 		$this->convertOutResponse($response);
 		return $response;
 	}


### PR DESCRIPTION
This PR adds a debugCommunication flag to Config to get curl debug info in the Response.
This flag was formerly added to pmgw/payment-gateway-php-sdk in 3.10.0 (https://github.com/pmgw-hu/payment-gateway-php-sdk/compare/3.9.0...3.10.0) based on @smatyas's PR (https://github.com/pmgw-hu/payment-gateway-php-sdk/pull/5).

Please add this feature to this repo too.